### PR TITLE
Solid color option

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -23,6 +23,9 @@
   "options_thumbnail_blurred": {
     "message": "Blurred"
   },
+  "options_thumbnail_solid_color": {
+    "message": "Solid color"
+  },
   "options_thumbnail_normal": {
     "message": "Normal"
   },

--- a/_locales/es/messages.json
+++ b/_locales/es/messages.json
@@ -23,6 +23,9 @@
   "options_thumbnail_blurred": {
     "message": "Borrosa"
   },
+  "options_thumbnail_solid_color": {
+    "message": "Color sólido"
+  },
   "options_thumbnail_normal": {
     "message": "Normal"
   },

--- a/common.js
+++ b/common.js
@@ -7,7 +7,7 @@ if (typeof globalThis.browser === "undefined") {
 /**
  * @typedef {{
  *   syncSettings: boolean,
- *   thumbnailMode: 'hidden' | 'hidden-except-hover' | 'blurred' | 'normal',
+ *   thumbnailMode: 'hidden' | 'hidden-except-hover' | 'blurred' | 'normal' | 'solid-color',
  *   disabledOnPages: {
  *     results: boolean,
  *     playlist: boolean,

--- a/common.js
+++ b/common.js
@@ -7,7 +7,7 @@ if (typeof globalThis.browser === "undefined") {
 /**
  * @typedef {{
  *   syncSettings: boolean,
- *   thumbnailMode: 'hidden' | 'hidden-except-hover' | 'blurred' | 'normal' | 'solid-color',
+ *   thumbnailMode: 'hidden' | 'hidden-except-hover' | 'blurred' | 'solid-color' | 'normal',
  *   disabledOnPages: {
  *     results: boolean,
  *     playlist: boolean,
@@ -18,6 +18,7 @@ if (typeof globalThis.browser === "undefined") {
  * }} Options
  */
 
+/** @type {Options} */
 const defaultOptions = {
   syncSettings: true,
   disabledOnPages: {

--- a/inject.js
+++ b/inject.js
@@ -45,7 +45,18 @@ ytd-playlist-video-renderer:not(:hover) ytd-thumbnail,
   "solid-color": `
 .yt-core-image {
   display: none !important;
-}`,
+  background-color: var(--yt-spec-additive-background);
+}
+
+ytd-thumbnail.style-scope.ytd-compact-video-renderer {
+  background-color: var(--yt-spec-additive-background);
+  border-radius: 1rem;
+}
+
+ytd-thumbnail #thumbnail.ytd-thumbnail {
+  background-color: var(--yt-spec-additive-background);
+}
+`,
 };
 
 const elem = document.createElement("style");

--- a/inject.js
+++ b/inject.js
@@ -55,8 +55,7 @@ ytd-thumbnail.style-scope.ytd-compact-video-renderer {
 
 ytd-thumbnail #thumbnail.ytd-thumbnail {
   background-color: var(--yt-spec-additive-background);
-}
-`,
+}`,
 };
 
 const elem = document.createElement("style");

--- a/inject.js
+++ b/inject.js
@@ -42,7 +42,11 @@ ytd-playlist-video-renderer:not(:hover) ytd-thumbnail,
   "blurred": `ytd-thumbnail img, ytd-playlist-thumbnail img, .video-thumbnail-img {
   filter: blur(16px);
 }`,
-}
+  "solid-color": `
+.yt-core-image {
+  display: none !important;
+}`,
+};
 
 const elem = document.createElement("style");
 document.documentElement.appendChild(elem);

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "manifest_version": 3,
-  "version": "2.1.0",
+  "version": "2.1.1",
   "name": "__MSG_extName__",
   "description": "__MSG_extDescription__",
   "homepage_url": "https://github.com/domdomegg/hideytthumbnails-extension",

--- a/options.html
+++ b/options.html
@@ -19,10 +19,10 @@
       <label for="hidden-except-hover" data-i18n="options_thumbnail_hidden_except_hovered">Hidden (except when hovered)</label><br />
       <input type="radio" name="thumbnailMode" id="blurred" value="blurred">
       <label for="blurred" data-i18n="options_thumbnail_blurred">Blurred</label><br />
-      <input type="radio" name="thumbnailMode" id="normal" value="normal">
-      <label for="normal" data-i18n="options_thumbnail_normal">Normal</label><br />
       <input type="radio" name="thumbnailMode" id="solid-color" value="solid-color">
       <label for="solid-color" data-i18n="options_thumbnail_solid_color">Solid color</label><br />
+      <input type="radio" name="thumbnailMode" id="normal" value="normal">
+      <label for="normal" data-i18n="options_thumbnail_normal">Normal</label><br />
       <br />
       
       <p data-i18n="options_disable_extension_on">Disable extension on</p>

--- a/options.html
+++ b/options.html
@@ -21,6 +21,8 @@
       <label for="blurred" data-i18n="options_thumbnail_blurred">Blurred</label><br />
       <input type="radio" name="thumbnailMode" id="normal" value="normal">
       <label for="normal" data-i18n="options_thumbnail_normal">Normal</label><br />
+      <input type="radio" name="thumbnailMode" id="solid-color" value="solid-color">
+      <label for="solid-color" data-i18n="options_thumbnail_solid_color">Solid color</label><br />
       <br />
       
       <p data-i18n="options_disable_extension_on">Disable extension on</p>


### PR DESCRIPTION
Yoyo,
 
I was hoping for an option that didn't edit the layout of youtube, as I wanted to scan youtube the same but hide thumbnails.

I wanted to add a new option for "solid color". I was thinking of adding a color picker, but didn't wanna change too much at once.

My changes just hide the image element showing only the default grey background.

Let me know what you think,
Isaiah

