### PR TITLE
Only hide thumbnails during set timeframe

### DIFF
--- a/common.js
+++ b/common.js
@@ -28,6 +28,11 @@ const defaultOptions = {
     everywhere: false,
   },
   thumbnailMode: 'hidden',
+  workMode: {
+    enabled: false,
+    startTime: "09:00",
+    endTime: "17:00",
+  },
 }
 
 /**

--- a/inject.js
+++ b/inject.js
@@ -47,6 +47,22 @@ ytd-playlist-video-renderer:not(:hover) ytd-thumbnail,
 const elem = document.createElement("style");
 document.documentElement.appendChild(elem);
 
+const IsItWorkTime = (startTime, endTime)=>{
+  currentDate = new Date();
+
+  startDate = new Date(currentDate.getTime());
+  startDate.setHours(startTime.split(":")[0]);
+  startDate.setMinutes(startTime.split(":")[1]);
+  startDate.setSeconds(0);
+
+  endDate = new Date(currentDate.getTime());
+  endDate.setHours(endTime.split(":")[0]);
+  endDate.setMinutes(endTime.split(":")[1]);
+  endDate.setSeconds(0);
+
+  return currentDate > startDate && currentDate < endDate;
+}
+
 const updateElem = async () => {
   const options = await loadOptions()
 
@@ -56,8 +72,20 @@ const updateElem = async () => {
     || (options.disabledOnPages.watch && window.location.pathname === '/watch')
     || (options.disabledOnPages.subscriptions && window.location.pathname === '/feed/subscriptions');
 
-  elem.innerHTML = `/* Injected by the Hide YouTube Thumbnails extension */
-  ${css[isDisabled ? 'normal' : options.thumbnailMode]}`
+  if(options.workMode.enabled){
+
+    if(IsItWorkTime(options.workMode.startTime, options.workMode.endTime)){
+      elem.innerHTML = `/* Injected by the Hide YouTube Thumbnails extension */
+      ${css[options.thumbnailMode]}`
+    }else{
+      elem.innerHTML = `/* Injected by the Hide YouTube Thumbnails extension */
+      ${css["normal"]}`
+    }
+  }else{
+    elem.innerHTML = `/* Injected by the Hide YouTube Thumbnails extension */
+    ${css[isDisabled ? 'normal' : options.thumbnailMode]}`
+  }
+
 }
 
 // Update when settings are changed

--- a/options.html
+++ b/options.html
@@ -36,6 +36,16 @@
       <label for="disableEverywhere" data-i18n="options_disable_extension_everywhere">Everywhere</label><br />
       <br />
 
+      <p data-i18n="options_work_mode">Work Mode</p>
+      <p data-i18n="options_work_mode_description">Only hide thumbnails during a set time of the day</p>
+      <input type="checkbox" name="enableWorkMode" id="enableWorkMode">
+      <label for="enableWorkMode" data-i18n="options_enable_work_mode">Enabled</label><br />
+      <label for="workModeStart">Start date:</label>
+      <input type="time" id="workModeStart" name="workModeStart" >
+
+      <label for="workModeEnd">End date:</label>
+      <input type="time" id="workModeEnd" name="workModeEnd" >
+
       <p id="status">✅ <span data-i18n="options_loaded">Preferences loaded</span></p>
     </form>
     <script src="common.js"></script>

--- a/options.js
+++ b/options.js
@@ -11,13 +11,23 @@ document.addEventListener('DOMContentLoaded', async () => {
 
   // Load existing settings
   const options = await loadOptions();
+  //Settings storage
   document.forms[0].syncSettings.checked = options.syncSettings;
+  
+  //Thumbnail mode
   document.forms[0].thumbnailMode.value = options.thumbnailMode;
+  
+  //Disabled pages
   document.forms[0].disableSearchResultPage.checked = options.disabledOnPages.results;
   document.forms[0].disablePlaylistPage.checked = options.disabledOnPages.playlist;
   document.forms[0].disableWatchPage.checked = options.disabledOnPages.watch;
   document.forms[0].disableSubscriptionsPage.checked = options.disabledOnPages.subscriptions;
   document.forms[0].disableEverywhere.checked = options.disabledOnPages.everywhere;
+  
+  //Work Mode
+  document.forms[0].enableWorkMode.checked = options.workMode.enabled;
+  document.forms[0].workModeStart.value = options.workMode.startTime;
+  document.forms[0].workModeEnd.value = options.workMode.endTime;
 });
 
 // Save on change
@@ -34,6 +44,11 @@ document.forms[0].addEventListener('change', async () => {
       watch: document.forms[0].disableWatchPage.checked,
       subscriptions: document.forms[0].disableSubscriptionsPage.checked,
       everywhere: document.forms[0].disableEverywhere.checked,
+    },
+    workMode: {
+      enabled: document.forms[0].enableWorkMode.checked,
+      startTime: document.forms[0].workModeStart.value,
+      endTime: document.forms[0].workModeEnd.value,
     },
   })
 


### PR DESCRIPTION
If work mode is enabled:
* If it's current work time, hide/blur/etc thumbnails.
* If it's not work time, show thumbnails/disable extension

if work mode is disabled:
* Extension acts normally

Added "work mode" ability to only hide thumbnails during a set timeframe. Disabled by default, default time frame from 9am-5pm.

Please check the updateElem function, because I overrode the main functionality and would be open to a better way. 

