### PR TITLE
Add new opt-in options aimed at reducing distractions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,173 @@
+# Hide YouTube Thumbnails Extension: Developer Documentation
+
+## Overview
+
+This browser extension is designed to hide or modify the appearance of video thumbnails and related elements on YouTube. It provides users with several modes for thumbnail display (hidden, blurred, solid color, etc.) and allows fine-grained control over where the extension is active. The extension is implemented using standard WebExtension APIs and is compatible with both Firefox and Chromium-based browsers.
+
+---
+
+## File Structure and Key Components
+
+- **manifest.json**: Declares the extension's metadata, permissions, content scripts, options UI, and localization.
+- **inject.js**: The main content script that injects CSS into YouTube pages to hide or modify thumbnails based on user settings.
+- **options.html**: The options page UI, allowing users to configure how and where the extension operates.
+- **options.js**: Handles logic for loading, saving, and syncing user preferences in the options page.
+- **common.js**: (Not shown here) Expected to provide shared functions like `loadOptions()` used by both `inject.js` and `options.js`.
+- **_locales/**: Contains translation files for internationalization.
+
+---
+
+## How the Options Page Works (`options.html` & `options.js`)
+
+### `options.html`
+- Provides a form UI for users to:
+  - Choose how thumbnails are displayed (hidden, blurred, etc.).
+  - Select which YouTube pages the extension is disabled on.
+  - Enable/disable syncing settings across browsers.
+- Uses `data-i18n` attributes for localization.
+- Loads `common.js` and `options.js` for logic and shared functions.
+
+### `options.js`
+- On page load (`DOMContentLoaded`):
+  - Localizes all elements with `data-i18n` using `browser.i18n.getMessage`.
+  - Loads saved options via `loadOptions()` and updates the form fields accordingly.
+- On form change:
+  - Saves the new options to `browser.storage.local` (and `browser.storage.sync` if syncing is enabled).
+  - Shows a temporary "saving" status, then updates to "saved".
+- **Example: Saving Options**
+  ```js
+  await saveOptions({
+    syncSettings: document.forms[0].syncSettings.checked,
+    thumbnailMode: document.forms[0].thumbnailMode.value,
+    disabledOnPages: {
+      results: document.forms[0].disableSearchResultPage.checked,
+      // ...other page options...
+    },
+  })
+  ```
+
+---
+
+## How the Content Script Works (`inject.js`)
+
+### Core Logic
+- Defines several CSS templates for different thumbnail modes (hidden, blurred, etc.).
+- Injects a `<style>` element into the page and updates its contents based on user settings.
+- Listens for changes in storage (settings) and page navigation to update the CSS dynamically.
+- Uses `loadOptions()` (from `common.js`) to fetch user preferences.
+- Determines if the extension should be disabled on the current page by checking the URL path and user settings.
+- Updates the injected CSS whenever:
+  - The user changes settings in the options page.
+  - The user navigates to a different YouTube page (using a polling interval to detect path changes).
+
+### Example: Injecting CSS Based on Settings
+```js
+const updateElem = async () => {
+  const options = await loadOptions();
+  const isDisabled = options.disabledOnPages.everywhere
+    || (options.disabledOnPages.results && window.location.pathname === '/results')
+    // ...other page checks...
+  elem.innerHTML = `/* Injected by the Hide YouTube Thumbnails extension */\n  ${css[isDisabled ? 'normal' : options.thumbnailMode]}`;
+}
+```
+
+---
+
+## How `options.html` and `options.js` Work Together
+
+- The options page UI (`options.html`) provides form controls for all user-configurable settings.
+- `options.js`:
+  - Loads the current settings and updates the form fields on page load.
+  - Listens for changes to the form and saves the new settings.
+  - Provides user feedback ("saving", "saved") in the UI.
+- All settings are stored in `browser.storage.local` (and optionally `browser.storage.sync`), making them accessible to the content script (`inject.js`).
+
+---
+
+## How to Extend the Extension
+
+### 1. Add a New Thumbnail Mode
+- Define a new CSS template in `inject.js`:
+  ```js
+  const cssNewMode = `
+    /* Your new CSS rules here */
+  `;
+  css['new-mode'] = cssNewMode;
+  ```
+- Add a new radio button to `options.html`:
+  ```html
+  <input type="radio" name="thumbnailMode" id="new-mode" value="new-mode">
+  <label for="new-mode">New Mode</label><br />
+  ```
+- Update localization files in `_locales/` for the new label.
+
+### 2. Hide/Modify Additional Elements
+- Add new CSS selectors to the relevant CSS template in `inject.js`.
+- Example:
+  ```js
+  const cssHidden = `
+    // ...existing selectors...
+    .new-youtube-element {
+      display: none !important;
+    }
+  `;
+  ```
+
+### 3. Add More Per-Page Controls
+- Add new checkboxes to `options.html` for additional YouTube page types.
+- Update the `disabledOnPages` object in both `options.js` and `inject.js` to handle the new page type.
+- Example:
+  ```js
+  // options.js
+  document.forms[0].disableNewPage.checked = options.disabledOnPages.newPage;
+  // inject.js
+  || (options.disabledOnPages.newPage && window.location.pathname === '/newpage')
+  ```
+
+### 4. Add More Settings
+- Add new form fields to `options.html`.
+- Update `options.js` to load and save the new setting.
+- Update `inject.js` to use the new setting as needed.
+
+---
+
+## Code Example: Adding a New Setting
+Suppose you want to add an option to hide video titles:
+
+1. **Add a checkbox to `options.html`:**
+   ```html
+   <input type="checkbox" name="hideTitles" id="hideTitles">
+   <label for="hideTitles">Hide video titles</label><br />
+   ```
+2. **Update `options.js` to load/save the new setting:**
+   ```js
+   document.forms[0].hideTitles.checked = options.hideTitles;
+   // ...
+   await saveOptions({
+     // ...existing options...
+     hideTitles: document.forms[0].hideTitles.checked,
+   });
+   ```
+3. **Update `inject.js` to apply the new setting:**
+   ```js
+   if (options.hideTitles) {
+     elem.innerHTML += '\nytd-video-renderer #video-title { display: none !important; }';
+   }
+   ```
+
+---
+
+## Best Practices
+- Use the `browser` namespace for cross-browser compatibility.
+- Always update localization files when adding new UI elements.
+- Test changes on different YouTube page types to ensure selectors are correct.
+- Keep CSS selectors as specific as possible to avoid unintended side effects.
+
+---
+
+## References
+- [WebExtensions API documentation (MDN)](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions)
+- [YouTube DOM structure (for selectors)](https://www.youtube.com/)
+- [Project GitHub Repository](https://github.com/domdomegg/hideytthumbnails-extension)
+
+

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -58,5 +58,14 @@
   },
   "options_saved": {
     "message": "Saved preferences"
+  },
+  "options_hide_avatars": {
+    "message": "Channel avatars display"
+  },
+  "options_avatar_normal": {
+    "message": "Normal"
+  },
+  "options_avatar_hidden": {
+    "message": "Hidden"
   }
 }

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -85,5 +85,8 @@
   },
   "options_title_format_sentencecase": {
     "message": "Sentence case"
+  },
+  "options_remove_emojis_from_titles": {
+    "message": "Remove emojis from video titles ❤️"
   }
 }

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -67,5 +67,23 @@
   },
   "options_avatar_hidden": {
     "message": "Hidden"
+  },
+  "options_title_format": {
+    "message": "Video title format"
+  },
+  "options_title_format_normal": {
+    "message": "Normal"
+  },
+  "options_title_format_titlecase": {
+    "message": "Title Case"
+  },
+  "options_title_format_lowercase": {
+    "message": "lowercase"
+  },
+  "options_title_format_uppercase": {
+    "message": "UPPERCASE"
+  },
+  "options_title_format_sentencecase": {
+    "message": "Sentence case"
   }
 }

--- a/_locales/es/messages.json
+++ b/_locales/es/messages.json
@@ -36,7 +36,7 @@
     "message": "Página de resultados de búsqueda"
   },
   "options_disable_extension_channel": {
-   "message": "Página de canal"
+    "message": "Página de canal"
   },
   "options_disable_extension_playlist": {
     "message": "Página de lista de reproducción"
@@ -67,5 +67,23 @@
   },
   "options_avatar_hidden": {
     "message": "Oculto"
+  },
+  "options_title_format": {
+    "message": "Formato del título del video"
+  },
+  "options_title_format_normal": {
+    "message": "Normal"
+  },
+  "options_title_format_titlecase": {
+    "message": "Mayúsculas Iniciales"
+  },
+  "options_title_format_lowercase": {
+    "message": "minúsculas"
+  },
+  "options_title_format_uppercase": {
+    "message": "MAYÚSCULAS"
+  },
+  "options_title_format_sentencecase": {
+    "message": "Frase"
   }
 }

--- a/_locales/es/messages.json
+++ b/_locales/es/messages.json
@@ -85,5 +85,8 @@
   },
   "options_title_format_sentencecase": {
     "message": "Frase"
+  },
+  "options_remove_emojis_from_titles": {
+    "message": "Eliminar emojis de los títulos de los videos ❤️"
   }
 }

--- a/_locales/es/messages.json
+++ b/_locales/es/messages.json
@@ -44,6 +44,9 @@
   "options_disable_extension_watch": {
     "message": "Página de visualización"
   },
+  "options_disable_extension_subscriptions": {
+    "message": "Página de suscripciones"
+  },
   "options_disable_extension_everywhere": {
     "message": "En todas partes"
   },
@@ -55,5 +58,14 @@
   },
   "options_saved": {
     "message": "Preferencias guardadas"
+  },
+  "options_hide_avatars": {
+    "message": "Visualización de avatares de canal"
+  },
+  "options_avatar_normal": {
+    "message": "Normal"
+  },
+  "options_avatar_hidden": {
+    "message": "Oculto"
   }
 }

--- a/_locales/fr/messages.json
+++ b/_locales/fr/messages.json
@@ -67,5 +67,23 @@
   },
   "options_avatar_hidden": {
     "message": "Masqué"
+  },
+  "options_title_format": {
+    "message": "Format du titre de la vidéo"
+  },
+  "options_title_format_normal": {
+    "message": "Normal"
+  },
+  "options_title_format_titlecase": {
+    "message": "Casse du titre"
+  },
+  "options_title_format_lowercase": {
+    "message": "minuscules"
+  },
+  "options_title_format_uppercase": {
+    "message": "MAJUSCULES"
+  },
+  "options_title_format_sentencecase": {
+    "message": "Phrase"
   }
 }

--- a/_locales/fr/messages.json
+++ b/_locales/fr/messages.json
@@ -85,5 +85,8 @@
   },
   "options_title_format_sentencecase": {
     "message": "Phrase"
+  },
+  "options_remove_emojis_from_titles": {
+    "message": "Supprimer les emojis des titres des vidéos ❤️"
   }
 }

--- a/_locales/fr/messages.json
+++ b/_locales/fr/messages.json
@@ -4,5 +4,68 @@
   },
   "extDescription": {
     "message": "Masquer les miniatures YouTube pour une meilleure navigation"
+  },
+  "options_setting_storage": {
+    "message": "Stockage des paramètres"
+  },
+  "options_sync": {
+    "message": "Synchroniser les paramètres entre les navigateurs"
+  },
+  "options_thumbnail_mode": {
+    "message": "Mode d'affichage des miniatures"
+  },
+  "options_thumbnail_hidden": {
+    "message": "Masqué"
+  },
+  "options_thumbnail_hidden_except_hovered": {
+    "message": "Masqué (sauf au survol)"
+  },
+  "options_thumbnail_blurred": {
+    "message": "Flou"
+  },
+  "options_thumbnail_solid_color": {
+    "message": "Couleur unie"
+  },
+  "options_thumbnail_normal": {
+    "message": "Normal"
+  },
+  "options_disable_extension_on": {
+    "message": "Désactiver l'extension sur"
+  },
+  "options_disable_extension_results": {
+    "message": "Page de résultats de recherche"
+  },
+  "options_disable_extension_channel": {
+    "message": "Page de chaîne"
+  },
+  "options_disable_extension_playlist": {
+    "message": "Page de playlist"
+  },
+  "options_disable_extension_watch": {
+    "message": "Page de visionnage"
+  },
+  "options_disable_extension_subscriptions": {
+    "message": "Page des abonnements"
+  },
+  "options_disable_extension_everywhere": {
+    "message": "Partout"
+  },
+  "options_loaded": {
+    "message": "Préférences chargées"
+  },
+  "options_saving": {
+    "message": "Enregistrement..."
+  },
+  "options_saved": {
+    "message": "Préférences enregistrées"
+  },
+  "options_hide_avatars": {
+    "message": "Affichage des avatars de chaîne"
+  },
+  "options_avatar_normal": {
+    "message": "Normal"
+  },
+  "options_avatar_hidden": {
+    "message": "Masqué"
   }
 }

--- a/_locales/it/messages.json
+++ b/_locales/it/messages.json
@@ -85,5 +85,8 @@
   },
   "options_title_format_sentencecase": {
     "message": "Frase"
+  },
+  "options_remove_emojis_from_titles": {
+    "message": "Rimuovi le emoji dai titoli dei video ❤️"
   }
 }

--- a/_locales/it/messages.json
+++ b/_locales/it/messages.json
@@ -67,5 +67,23 @@
   },
   "options_avatar_hidden": {
     "message": "Nascosto"
+  },
+  "options_title_format": {
+    "message": "Formato del titolo del video"
+  },
+  "options_title_format_normal": {
+    "message": "Normale"
+  },
+  "options_title_format_titlecase": {
+    "message": "Titolo Maiuscolo"
+  },
+  "options_title_format_lowercase": {
+    "message": "minuscolo"
+  },
+  "options_title_format_uppercase": {
+    "message": "MAIUSCOLO"
+  },
+  "options_title_format_sentencecase": {
+    "message": "Frase"
   }
 }

--- a/_locales/it/messages.json
+++ b/_locales/it/messages.json
@@ -4,5 +4,68 @@
   },
   "extDescription": {
     "message": "Nascondi le miniature di YouTube per una migliore navigazione"
+  },
+  "options_setting_storage": {
+    "message": "Impostazioni di archiviazione"
+  },
+  "options_sync": {
+    "message": "Sincronizza le impostazioni tra i browser"
+  },
+  "options_thumbnail_mode": {
+    "message": "Modalità di visualizzazione delle miniature"
+  },
+  "options_thumbnail_hidden": {
+    "message": "Nascosto"
+  },
+  "options_thumbnail_hidden_except_hovered": {
+    "message": "Nascosto (eccetto al passaggio del mouse)"
+  },
+  "options_thumbnail_blurred": {
+    "message": "Sfocato"
+  },
+  "options_thumbnail_solid_color": {
+    "message": "Colore solido"
+  },
+  "options_thumbnail_normal": {
+    "message": "Normale"
+  },
+  "options_disable_extension_on": {
+    "message": "Disabilita estensione su"
+  },
+  "options_disable_extension_results": {
+    "message": "Pagina dei risultati di ricerca"
+  },
+  "options_disable_extension_channel": {
+    "message": "Pagina del canale"
+  },
+  "options_disable_extension_playlist": {
+    "message": "Pagina della playlist"
+  },
+  "options_disable_extension_watch": {
+    "message": "Pagina di visualizzazione"
+  },
+  "options_disable_extension_subscriptions": {
+    "message": "Pagina delle iscrizioni"
+  },
+  "options_disable_extension_everywhere": {
+    "message": "Ovunque"
+  },
+  "options_loaded": {
+    "message": "Preferenze caricate"
+  },
+  "options_saving": {
+    "message": "Salvataggio..."
+  },
+  "options_saved": {
+    "message": "Preferenze salvate"
+  },
+  "options_hide_avatars": {
+    "message": "Visualizzazione avatar canale"
+  },
+  "options_avatar_normal": {
+    "message": "Normale"
+  },
+  "options_avatar_hidden": {
+    "message": "Nascosto"
   }
 }

--- a/_locales/pt/messages.json
+++ b/_locales/pt/messages.json
@@ -67,5 +67,23 @@
   },
   "options_avatar_hidden": {
     "message": "Oculto"
+  },
+  "options_title_format": {
+    "message": "Formato do título do vídeo"
+  },
+  "options_title_format_normal": {
+    "message": "Normal"
+  },
+  "options_title_format_titlecase": {
+    "message": "Primeira Maiúscula"
+  },
+  "options_title_format_lowercase": {
+    "message": "minúsculas"
+  },
+  "options_title_format_uppercase": {
+    "message": "MAIÚSCULAS"
+  },
+  "options_title_format_sentencecase": {
+    "message": "Frase"
   }
 }

--- a/_locales/pt/messages.json
+++ b/_locales/pt/messages.json
@@ -85,5 +85,8 @@
   },
   "options_title_format_sentencecase": {
     "message": "Frase"
+  },
+  "options_remove_emojis_from_titles": {
+    "message": "Remover emojis dos títulos dos vídeos ❤️"
   }
 }

--- a/_locales/pt/messages.json
+++ b/_locales/pt/messages.json
@@ -4,5 +4,68 @@
   },
   "extDescription": {
     "message": "Ocultar miniaturas do YouTube para navegar melhor"
+  },
+  "options_setting_storage": {
+    "message": "Configuração de armazenamento"
+  },
+  "options_sync": {
+    "message": "Sincronizar configurações entre navegadores"
+  },
+  "options_thumbnail_mode": {
+    "message": "Modo de exibição de miniaturas"
+  },
+  "options_thumbnail_hidden": {
+    "message": "Oculto"
+  },
+  "options_thumbnail_hidden_except_hovered": {
+    "message": "Oculto (exceto quando pairado)"
+  },
+  "options_thumbnail_blurred": {
+    "message": "Desfocado"
+  },
+  "options_thumbnail_solid_color": {
+    "message": "Cor sólida"
+  },
+  "options_thumbnail_normal": {
+    "message": "Normal"
+  },
+  "options_disable_extension_on": {
+    "message": "Desativar extensão em"
+  },
+  "options_disable_extension_results": {
+    "message": "Página de resultados de pesquisa"
+  },
+  "options_disable_extension_channel": {
+    "message": "Página do canal"
+  },
+  "options_disable_extension_playlist": {
+    "message": "Página da playlist"
+  },
+  "options_disable_extension_watch": {
+    "message": "Página de exibição"
+  },
+  "options_disable_extension_subscriptions": {
+    "message": "Página de inscrições"
+  },
+  "options_disable_extension_everywhere": {
+    "message": "Em todo lugar"
+  },
+  "options_loaded": {
+    "message": "Preferências carregadas"
+  },
+  "options_saving": {
+    "message": "Salvando..."
+  },
+  "options_saved": {
+    "message": "Preferências salvas"
+  },
+  "options_hide_avatars": {
+    "message": "Exibição de avatares do canal"
+  },
+  "options_avatar_normal": {
+    "message": "Normal"
+  },
+  "options_avatar_hidden": {
+    "message": "Oculto"
   }
 }

--- a/common.js
+++ b/common.js
@@ -17,6 +17,7 @@ if (typeof globalThis.browser === "undefined") {
  *     everywhere: boolean,
  *   },
  *   avatarMode: 'normal' | 'hidden',
+ *   titleFormat: 'normal' | 'titlecase' | 'lowercase' | 'uppercase' | 'sentencecase',
  * }} Options
  */
 
@@ -33,6 +34,7 @@ const defaultOptions = {
   },
   thumbnailMode: 'hidden',
   avatarMode: 'normal',
+  titleFormat: 'normal',
 }
 
 /**

--- a/common.js
+++ b/common.js
@@ -18,6 +18,7 @@ if (typeof globalThis.browser === "undefined") {
  *   },
  *   avatarMode: 'normal' | 'hidden',
  *   titleFormat: 'normal' | 'titlecase' | 'lowercase' | 'uppercase' | 'sentencecase',
+ *   removeEmojisFromTitles: boolean,
  * }} Options
  */
 
@@ -35,6 +36,7 @@ const defaultOptions = {
   thumbnailMode: 'hidden',
   avatarMode: 'normal',
   titleFormat: 'normal',
+  removeEmojisFromTitles: false,
 }
 
 /**

--- a/common.js
+++ b/common.js
@@ -16,6 +16,7 @@ if (typeof globalThis.browser === "undefined") {
  *     subscriptions: boolean,
  *     everywhere: boolean,
  *   },
+ *   avatarMode: 'normal' | 'hidden',
  * }} Options
  */
 
@@ -31,6 +32,7 @@ const defaultOptions = {
     everywhere: false,
   },
   thumbnailMode: 'hidden',
+  avatarMode: 'normal',
 }
 
 /**

--- a/inject.js
+++ b/inject.js
@@ -91,7 +91,7 @@ ytm-shorts-lockup-view-model .shortsLockupViewModelHostThumbnailContainer,
   opacity: 1 !important;
 }`,
   "hide-avatar": `
-#avatar-container, yt-img-shadow#avatar, .ytd-comment-view-model #author-thumbnail-button, #creator-thumbnail, #creator-heart, tp-yt-paper-item > yt-img-shadow img, ytm-channel-thumbnail-with-link-renderer {
+#avatar-container, yt-img-shadow#avatar, .ytd-comment-view-model #author-thumbnail-button, #creator-thumbnail, #creator-heart, tp-yt-paper-item > yt-img-shadow img, ytm-channel-thumbnail-with-link-renderer, .yt-lockup-metadata-view-model-wiz__avatar {
   display: none !important;
 }`
 };

--- a/inject.js
+++ b/inject.js
@@ -91,7 +91,7 @@ ytm-shorts-lockup-view-model .shortsLockupViewModelHostThumbnailContainer,
   opacity: 1 !important;
 }`,
   "hide-avatar": `
-#avatar-container, yt-img-shadow#avatar, .ytd-comment-view-model #author-thumbnail-button, #creator-thumbnail, #creator-heart, tp-yt-paper-item > yt-img-shadow img, ytm-channel-thumbnail-with-link-renderer, .yt-lockup-metadata-view-model-wiz__avatar {
+#avatar-container, yt-img-shadow#avatar, .ytd-comment-view-model #author-thumbnail-button, #creator-thumbnail, #creator-heart, tp-yt-paper-item > yt-img-shadow img, ytm-channel-thumbnail-with-link-renderer, .yt-lockup-metadata-view-model-wiz__avatar, yt-lockup-view-model > div > a, .yt-lockup-metadata-view-model__avatar {
   display: none !important;
 }`
 };

--- a/inject.js
+++ b/inject.js
@@ -91,7 +91,7 @@ ytm-shorts-lockup-view-model .shortsLockupViewModelHostThumbnailContainer,
   opacity: 1 !important;
 }`,
   "hide-avatar": `
-#avatar-container, yt-img-shadow#avatar, .ytd-comment-view-model #author-thumbnail-button, #creator-thumbnail, #creator-heart, tp-yt-paper-item > yt-img-shadow img {
+#avatar-container, yt-img-shadow#avatar, .ytd-comment-view-model #author-thumbnail-button, #creator-thumbnail, #creator-heart, tp-yt-paper-item > yt-img-shadow img, ytm-channel-thumbnail-with-link-renderer {
   display: none !important;
 }`
 };
@@ -140,7 +140,7 @@ let titleObserver = null;
 const normalizeTitles = (format, options) => {
   const { removeEmojis } = options || {};
 
-  document.addEventListener('DOMContentLoaded', () => {
+  const setupObserver = () => {
     if (titleObserver) {
       titleObserver.disconnect();
     }
@@ -182,7 +182,14 @@ const normalizeTitles = (format, options) => {
       childList: true,
       subtree: true
     });
-  })
+  };
+
+  // If the document is still loading, wait for it to be ready before setting up the observer
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', setupObserver);
+  } else {
+    setupObserver();
+  }
 };
 
 const updateElem = async () => {

--- a/inject.js
+++ b/inject.js
@@ -90,6 +90,10 @@ ytm-shorts-lockup-view-model .shortsLockupViewModelHostThumbnailContainer,
 .ytp-videowall-still-info-content {
   opacity: 1 !important;
 }`,
+  "hide-avatar": `
+#avatar-container, yt-img-shadow#avatar, .ytd-comment-view-model #author-thumbnail-button, #creator-thumbnail, #creator-heart {
+  display: none !important;
+}`
 };
 
 const elem = document.createElement("style");
@@ -105,8 +109,15 @@ const updateElem = async () => {
     || (options.disabledOnPages.watch && window.location.pathname === '/watch')
     || (options.disabledOnPages.subscriptions && window.location.pathname === '/feed/subscriptions');
 
-  elem.innerHTML = `/* Injected by the Hide YouTube Thumbnails extension */
-  ${css[isDisabled ? 'normal' : options.thumbnailMode]}`
+  elem.innerHTML = `/* Injected by the Hide YouTube Thumbnails extension */\n`
+
+  if (!isDisabled) {
+    elem.innerHTML += `  ${css[options.thumbnailMode]}`;
+
+    if (options.avatarMode === 'hidden') {
+      elem.innerHTML += `\n${css['hide-avatar']}`;
+    }
+  }
 }
 
 // Update when settings are changed

--- a/options.html
+++ b/options.html
@@ -45,6 +45,12 @@
       <label for="title-format-uppercase" data-i18n="options_title_format_uppercase">UPPERCASE</label><br />
       <br />
 
+      <div>
+        <input type="checkbox" name="removeEmojisFromTitles" id="removeEmojisFromTitles">
+        <label for="removeEmojisFromTitles" data-i18n="options_remove_emojis_from_titles">Remove emojis from video titles ❤️</label>
+      </div>
+      <br />
+
       <p data-i18n="options_disable_extension_on">Disable extension on</p>
       <input type="checkbox" name="disableSearchResultPage" id="disableSearchResultPage">
       <label for="disableSearchResultPage" data-i18n="options_disable_extension_results">Search results page</label><br />

--- a/options.html
+++ b/options.html
@@ -32,6 +32,19 @@
       <label for="avatar-hidden" data-i18n="options_avatar_hidden">Hidden</label><br />
       <br />
 
+      <p data-i18n="options_title_format">Video title format</p>
+      <input type="radio" name="titleFormat" id="title-format-normal" value="normal" checked>
+      <label for="title-format-normal" data-i18n="options_title_format_normal">Normal</label><br />
+      <input type="radio" name="titleFormat" id="title-format-titlecase" value="titlecase">
+      <label for="title-format-titlecase" data-i18n="options_title_format_titlecase">Title Case</label><br />
+      <input type="radio" name="titleFormat" id="title-format-sentencecase" value="sentencecase">
+      <label for="title-format-sentencecase" data-i18n="options_title_format_sentencecase">Sentence case</label><br />
+      <input type="radio" name="titleFormat" id="title-format-lowercase" value="lowercase">
+      <label for="title-format-lowercase" data-i18n="options_title_format_lowercase">lowercase</label><br />
+      <input type="radio" name="titleFormat" id="title-format-uppercase" value="uppercase">
+      <label for="title-format-uppercase" data-i18n="options_title_format_uppercase">UPPERCASE</label><br />
+      <br />
+
       <p data-i18n="options_disable_extension_on">Disable extension on</p>
       <input type="checkbox" name="disableSearchResultPage" id="disableSearchResultPage">
       <label for="disableSearchResultPage" data-i18n="options_disable_extension_results">Search results page</label><br />

--- a/options.html
+++ b/options.html
@@ -24,7 +24,14 @@
       <input type="radio" name="thumbnailMode" id="normal" value="normal">
       <label for="normal" data-i18n="options_thumbnail_normal">Normal</label><br />
       <br />
-      
+
+      <p data-i18n="options_hide_avatars">Channel avatars display</p>
+      <input type="radio" name="avatarMode" id="avatar-normal" value="normal" checked>
+      <label for="avatar-normal" data-i18n="options_avatar_normal">Normal</label><br />
+      <input type="radio" name="avatarMode" id="avatar-hidden" value="hidden">
+      <label for="avatar-hidden" data-i18n="options_avatar_hidden">Hidden</label><br />
+      <br />
+
       <p data-i18n="options_disable_extension_on">Disable extension on</p>
       <input type="checkbox" name="disableSearchResultPage" id="disableSearchResultPage">
       <label for="disableSearchResultPage" data-i18n="options_disable_extension_results">Search results page</label><br />

--- a/options.js
+++ b/options.js
@@ -19,6 +19,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   document.forms[0].disableWatchPage.checked = options.disabledOnPages.watch;
   document.forms[0].disableSubscriptionsPage.checked = options.disabledOnPages.subscriptions;
   document.forms[0].disableEverywhere.checked = options.disabledOnPages.everywhere;
+  document.forms[0].avatarMode.value = options.avatarMode ?? 'normal';
 });
 
 // Save on change
@@ -37,6 +38,7 @@ document.forms[0].addEventListener('change', async () => {
       subscriptions: document.forms[0].disableSubscriptionsPage.checked,
       everywhere: document.forms[0].disableEverywhere.checked,
     },
+    avatarMode: document.forms[0].avatarMode.value,
   })
 
   // Artificial delay, so the 'saving' message actually appears

--- a/options.js
+++ b/options.js
@@ -21,6 +21,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   document.forms[0].disableEverywhere.checked = options.disabledOnPages.everywhere;
   document.forms[0].avatarMode.value = options.avatarMode ?? 'normal';
   document.forms[0].titleFormat.value = options.titleFormat ?? 'normal';
+  document.forms[0].removeEmojisFromTitles.checked = options.removeEmojisFromTitles ?? false;
 });
 
 // Save on change
@@ -41,6 +42,7 @@ document.forms[0].addEventListener('change', async () => {
     },
     avatarMode: document.forms[0].avatarMode.value,
     titleFormat: document.forms[0].titleFormat.value,
+    removeEmojisFromTitles: document.forms[0].removeEmojisFromTitles.checked,
   })
 
   // Artificial delay, so the 'saving' message actually appears

--- a/options.js
+++ b/options.js
@@ -20,6 +20,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   document.forms[0].disableSubscriptionsPage.checked = options.disabledOnPages.subscriptions;
   document.forms[0].disableEverywhere.checked = options.disabledOnPages.everywhere;
   document.forms[0].avatarMode.value = options.avatarMode ?? 'normal';
+  document.forms[0].titleFormat.value = options.titleFormat ?? 'normal';
 });
 
 // Save on change
@@ -39,6 +40,7 @@ document.forms[0].addEventListener('change', async () => {
       everywhere: document.forms[0].disableEverywhere.checked,
     },
     avatarMode: document.forms[0].avatarMode.value,
+    titleFormat: document.forms[0].titleFormat.value,
   })
 
   // Artificial delay, so the 'saving' message actually appears


### PR DESCRIPTION
The new options are all disabled by default. This makes sure that users can optionally enabled them if they want.

## New options:
1. Remove channel avatars from the thumbnail card in the home page, in the sidebar, and video page. And user avatars in comments.
2. Format thumbnail and video suggestions titles.
3. Remove emojis from thumbnail and video suggestions titles.


<img width="439" height="707" alt="Screenshot from 2025-07-12 13-28-01" src="https://github.com/user-attachments/assets/8eadd7c3-be23-45b8-b081-66632126ac95" />


## Why?
As we all know, Youtube's algorithm rewards highly distracting tactics like titles with non-normalized formatting and emojis:

**Have YOU seen THIS??? 👉 Just 5 Minutes of This... Your Brain will MELT 🫠😵**

And also distracting channel or user avatars:

_**Think of any channel or user avatar**_

## Locales

Updated locales for English, Spanish, Italian, Portuguese and French using an LLM. I reviewed the English, Spanish and Italian versions and they are correct. Portuguese and French are very close to the Spanish and Italian and they look good to me as well.


## Agent instructions

Added `.github/copilot-instructions.md` to provide agents with context about the project.


## Technical implementation

### Emoji removal
Emoji removal uses a ["soft" regex](https://stackoverflow.com/questions/64509631/is-there-a-regex-to-match-all-unicode-emojis), so not all emojis are stripped. This is done this way to prevent false positives. For instance, the title:

```
Best of 2000s Electro Pop Hits! ❤️🎶📼🎧
```

Will be replaced with:

```
Best of 2000s Electro Pop Hits! ❤️
```

---

This was tested using the web version (https://www.youtube.com/) and in the following browsers:

- Brave: Version 1.77.100 Chromium: 135.0.7049.100 (Official Build) (64-bit)
- Chrome: Version 133.0.6943.126 (Official Build) (64-bit)
